### PR TITLE
Enhance aiohttp error reporting

### DIFF
--- a/webtop/__init__.py
+++ b/webtop/__init__.py
@@ -144,7 +144,18 @@ def build_stats(*, url: URL, method: str, results: Collection[Result]) -> dict:
             sum_latency += math.ceil(result.elapsed / datetime.timedelta(milliseconds=1))
             reason = f"HTTP {result.response.status}"
         elif isinstance(result, ErrorResult):
-            reason = str(type(result.error).__name__)
+            error = result.error
+            # aiohttp uses very generic errors, so we need to drill down
+            if isinstance(error, aiohttp.ClientConnectorError):
+                error = error.os_error
+            if isinstance(error, aiohttp.ClientConnectorCertificateError):
+                error = error.certificate_erro
+
+            reason = ''
+            error_module = type(error).__module__
+            if error_module:
+                reason += f'{error_module}.'
+            reason += type(error).__qualname__
 
         reason_counts[reason] = reason_counts.get(reason, 0) + 1
 

--- a/webtop/__init__.py
+++ b/webtop/__init__.py
@@ -151,10 +151,10 @@ def build_stats(*, url: URL, method: str, results: Collection[Result]) -> dict:
             if isinstance(error, aiohttp.ClientConnectorCertificateError):
                 error = error.certificate_error
 
-            reason = ''
+            reason = ""
             error_module = type(error).__module__
-            if error_module and error_module != 'builtins':
-                reason += f'{error_module}.'
+            if error_module and error_module != "builtins":
+                reason += f"{error_module}."
             reason += type(error).__qualname__
 
         reason_counts[reason] = reason_counts.get(reason, 0) + 1

--- a/webtop/__init__.py
+++ b/webtop/__init__.py
@@ -153,7 +153,7 @@ def build_stats(*, url: URL, method: str, results: Collection[Result]) -> dict:
 
             reason = ''
             error_module = type(error).__module__
-            if error_module:
+            if error_module and error_module != 'builtins':
                 reason += f'{error_module}.'
             reason += type(error).__qualname__
 

--- a/webtop/__init__.py
+++ b/webtop/__init__.py
@@ -149,7 +149,7 @@ def build_stats(*, url: URL, method: str, results: Collection[Result]) -> dict:
             if isinstance(error, aiohttp.ClientConnectorError):
                 error = error.os_error
             if isinstance(error, aiohttp.ClientConnectorCertificateError):
-                error = error.certificate_erro
+                error = error.certificate_error
 
             reason = ''
             error_module = type(error).__module__


### PR DESCRIPTION
In #5, the requests HTTP library was replaced with aiohttp. Request used different exception types for different TCP errors, while aiohttp colelcts them into less specific exceptions. This PR adds functionality to drill down into aiohttp exceptions to discover the root causes.