### PR TITLE
Fix duration bug

### DIFF
--- a/webtop/__init__.py
+++ b/webtop/__init__.py
@@ -95,7 +95,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def duration_is_vaild(duration: str) -> bool:
+def duration_is_valid(duration: Optional[str]) -> bool:
+    if duration is None:
+        return True
     try:
         durationpy.from_str(duration)
         return True
@@ -120,7 +122,7 @@ def are_args_valid(args: argparse.Namespace) -> bool:
             args.timeout > 0,
             args.workers > 0,
             args.resolve is None or ":" in args.resolve,
-            duration_is_vaild(args.duration),
+            duration_is_valid(args.duration),
         )
     )
 


### PR DESCRIPTION
Right now, webtop will crash if you don't specify a duration. Modified the validity check to include None.

Also, spelling is hard.