### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --virtual .build-dependencies build-base libressl libffi-dev && \
   pip install -r requirements.txt && \
   apk del .build-dependencies
 ADD webtop .
-ENTRYPOINT python webtop/__init__.py
+ENTRYPOINT python __init__.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --virtual .build-dependencies build-base libressl libffi-dev && \
   pip install -r requirements.txt && \
   apk del .build-dependencies
 ADD webtop .
-ENTRYPOINT python __init__.py
+ENTRYPOINT ["python", "__init__.py"]


### PR DESCRIPTION
`ADD webtop .` will copy the content of local webtop directory in the `cwd` directory of the docker image.
To copy the webtop directory itself in docker `cwd` we can use `ADD webtop ./webtop`, but it's easier to change the entrypoint :).
Also, use ENTRYPOINT in its exec form in order to be able to pass URL option as CMD parameter