### PR TITLE
Fix duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 .mypy_cache
+
+# IDE stuffs
+.idea

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,3 +1,3 @@
-black==19.3b0
-flake8==3.7.8
-mypy==0.720
+black==20.8b1
+flake8==3.8.4
+mypy==0.790

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiodns==2.0.0
-aiohttp==3.5.4
+aiohttp==3.7.2
 durationpy==0.5
-pyyaml==5.1.2
-yarl==1.3.0
+pyyaml==5.3.1
+yarl==1.6.3

--- a/webtop/__init__.py
+++ b/webtop/__init__.py
@@ -253,7 +253,7 @@ async def main() -> None:
         duration = durationpy.from_str(args.duration)
 
         async def stop_test():
-            await asyncio.wait([shutdown_event.wait()], timeout=duration)
+            await asyncio.wait([shutdown_event.wait()], timeout=duration.total_seconds())
             shutdown_event.set()
 
         tasks.append(stop_test())


### PR DESCRIPTION
I've noticed that if you specify the duration argument it will crash with:
``` 
$ webtop --request-history 50 --duration 1m https://aaaa/ping

Traceback (most recent call last):
  File "__init__.py", line 297, in <module>
    asyncio.run(main())
  File "/usr/local/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.7/asyncio/base_events.py", line 587, in run_until_complete
    return future.result()
  File "__init__.py", line 293, in main
    await asyncio.gather(*tasks)
  File "__init__.py", line 256, in stop_test
    await asyncio.wait([shutdown_event.wait()], timeout=duration)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 389, in wait
    return await _wait(fs, timeout, return_when, loop)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 463, in _wait
    timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
  File "/usr/local/lib/python3.7/asyncio/base_events.py", line 659, in call_later
    timer = self.call_at(self.time() + delay, callback, *args,
TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'
```

This PR converts the timeout value from `datetime.timedelta` to `float`. 
It is also updating the dependencies version.
 `make ci` passed:
```$ make ci
flake8 --ignore E501 webtop
mypy webtop
Success: no issues found in 1 source file
black --check --line-length 120 webtop
All done! ✨ 🍰 ✨
1 file would be left unchanged.
```